### PR TITLE
Remove mini language and update domain names

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -15,13 +15,13 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1.0, shrink-to-fit=no">
   <meta property="og:type" content="website">
-  <meta property="og:url" content="https://cosmicds.github.io/minids/jwst-brick/">
+  <meta property="og:url" content="https://projects.cosmicds.cfa.harvard.edu/jwst-brick/">
   <meta property="og:title" content="JWST Brick">
   <meta property="og:description"
     content="JWST Brick">
   <meta property="og:site_name" content="JWST Brick">
-  <meta property="og:image" content="https://cosmicds.github.io/minids/jwst-brick/preview.png">
-  <meta property="og:image:secure_url" content="https://cosmicds.github.io/minids/jwst-brick/preview.png">
+  <meta property="og:image" content="https://projects.cosmicds.cfa.harvard.edu/jwst-brick/preview.png">
+  <meta property="og:image:secure_url" content="https://projects.cosmicds.cfa.harvard.edu/jwst-brick/preview.png">
   <meta property="og:image:type" content="image/jpeg">
   <meta property="og:image:width" content="596">
   <meta property="og:image:height" content="886">
@@ -29,7 +29,7 @@
   <meta name="twitter:site" content="@CosmicDataStory">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:creator" content="@CosmicDataStory">
-  <meta name="twitter:image" content="https://cosmicds.github.io/minids/jwst-brick/preview.png">
+  <meta name="twitter:image" content="https://projects.cosmicds.cfa.harvard.edu/jwst-brick/preview.png">
   <link rel="icon" href="https://projects.cosmicds.cfa.harvard.edu/cds-website/cosmicds-favicon.png">
   <title>JWST Brick</title>
 </head>

--- a/src/JwstBrick.vue
+++ b/src/JwstBrick.vue
@@ -179,16 +179,16 @@
       <div id="project-credits">
         <div id="icons-container">
           <a href="https://www.cosmicds.cfa.harvard.edu/" target="_blank" rel="noopener noreferrer"
-          ><img alt="CosmicDS Logo" src="https://cosmicds.github.io/cds-website/logos/cosmicds_logo_for_dark_backgrounds.png"
+          ><img alt="CosmicDS Logo" src="https://projects.cosmicds.cfa.harvard.edu/cds-website/logos/cosmicds_logo_for_dark_backgrounds.png"
           /></a>
           <a href="https://worldwidetelescope.org/home/" target="_blank" rel="noopener noreferrer"
-            ><img alt="WWT Logo" src="https://cosmicds.github.io/cds-website/logos/logo_wwt.png"
+            ><img alt="WWT Logo" src="https://projects.cosmicds.cfa.harvard.edu/cds-website/logos/logo_wwt.png"
           /></a>
           <a href="https://science.nasa.gov/learners" target="_blank" rel="noopener noreferrer" class="pl-1"
-            ><img alt="SciAct Logo" src="https://cosmicds.github.io/cds-website/logos/logo_sciact.png"
+            ><img alt="SciAct Logo" src="https://projects.cosmicds.cfa.harvard.edu/cds-website/logos/logo_sciact.png"
           /></a>
           <a href="https://nasa.gov/" target="_blank" rel="noopener noreferrer" class="pl-1"
-            ><img alt="SciAct Logo" src="https://cosmicds.github.io/cds-website/logos/NASA_Partner_color_300_no_outline.png"
+            ><img alt="SciAct Logo" src="https://projects.cosmicds.cfa.harvard.edu/cds-website/logos/NASA_Partner_color_300_no_outline.png"
           /></a>
         </div>
       </div>
@@ -814,7 +814,7 @@ export default defineComponent({
 <style lang="less">
 @font-face {
   font-family: "Highway Gothic Narrow";
-  src: url("https://cosmicds.github.io/cds-website/fonts/HighwayGothicNarrow.ttf");
+  src: url("https://projects.cosmicds.cfa.harvard.edu/cds-website/fonts/HighwayGothicNarrow.ttf");
 }
 
 :root {
@@ -916,7 +916,7 @@ body {
     align-items: center;
     justify-content: center;
     .spinner {
-      background-image: url("https://cosmicds.github.io/cds-website/logos/lunar_loader.gif");
+      background-image: url("https://projects.cosmicds.cfa.harvard.edu/cds-website/logos/lunar_loader.gif");
       background-repeat: no-repeat;
       background-size: contain;
       width: 3rem;
@@ -941,7 +941,7 @@ body {
   div {
     margin: 0;
     padding: 0;
-    background-image: url("https://cosmicds.github.io/cds-website/logos/wwt_globe_bg.png");
+    background-image: url("https://projects.cosmicds.cfa.harvard.edu/cds-website/logos/wwt_globe_bg.png");
     background-repeat: no-repeat;
     background-size: contain;
     background-position: center;

--- a/src/JwstBrick.vue
+++ b/src/JwstBrick.vue
@@ -42,7 +42,7 @@
         </div>
         
         <div id="splash-screen-acknowledgements">
-          This Mini Data Story is brought to you by <a href="https://www.cosmicds.cfa.harvard.edu/" target="_blank" rel="noopener noreferrer">Cosmic Data Stories</a> and <a href="https://www.worldwidetelescope.org/home/" target="_blank" rel="noopener noreferrer">WorldWide Telescope</a>.
+          Brought to you by <a href="https://www.cosmicds.cfa.harvard.edu/" target="_blank" rel="noopener noreferrer">Cosmic Data Stories</a> and <a href="https://www.worldwidetelescope.org/home/" target="_blank" rel="noopener noreferrer">WorldWide Telescope</a>.
           
           <div id="splash-screen-logos">
             <credit-logos/>
@@ -339,7 +339,7 @@
                       <h3>Credits</h3>
 
 
-                      <h4><a href="https://www.cosmicds.cfa.harvard.edu/" target="_blank" rel="noopener noreferrer">CosmicDS</a> Mini Stories Team:</h4>
+                      <h4><a href="https://www.cosmicds.cfa.harvard.edu/" target="_blank" rel="noopener noreferrer">CosmicDS</a> Team:</h4>
                       John Lewis<br>
                       Pat Udomprasert<br>
                       Jon Carifio<br>
@@ -852,7 +852,7 @@ body {
 
 
 /*
-  The main content of the mini.
+  The main content of the data story.
   The --app-content-height allows the app to shrink when the text is open
  */
 #main-content {

--- a/src/main.ts
+++ b/src/main.ts
@@ -29,14 +29,14 @@ library.add(faLocationCrosshairs);
 const update = (el: HTMLElement, binding: Vue.DirectiveBinding) => el.style.visibility = (binding.value) ? "hidden" : "";
 
 createApp(JwstBrick, {
-  wwtNamespace: "wwt-minids-jwst-brick",
+  wwtNamespace: "wwt-jwst-brick",
   wtml: {
-    nostars: "https://cosmicds.github.io/cds-website/wwt-content/JWST-Brick-wostars/index.wtml",
-    stars: "https://cosmicds.github.io/cds-website/wwt-content/JWST-Brick-wstars/index.wtml",
-    // glimpse: "https://cosmicds.github.io/cds-website/wwt-content/glimpse_original.wtml",
+    nostars: "https://projects.cosmicds.cfa.harvard.edu/cds-website/wwt-content/JWST-Brick-wostars/index.wtml",
+    stars: "https://projects.cosmicds.cfa.harvard.edu/cds-website/wwt-content/JWST-Brick-wstars/index.wtml",
+    // glimpse: "https://projects.cosmicds.cfa.harvard.edu/cds-website/wwt-content/glimpse_original.wtml",
     zannotation: "https://raw.githubusercontent.com/johnarban/wwt_interactives/main/images/adam/annotation/index.wtml",
   },
-  bgWtml: "https://cosmicds.github.io/cds-website/wwt-content/glimpse_original.wtml",
+  bgWtml: "https://projects.cosmicds.cfa.harvard.edu/cds-website/wwt-content/glimpse_original.wtml",
   bgName: "GLIMPSE Original"
 })
  


### PR DESCRIPTION
This removes anything in the front end that refers to "mini" data stories and updates the domain name to use projects.cosmicds.cfa.harvard.edu instead of github.io