### PR TITLE
Use NASA Grantee logo and fix bad alt text

### DIFF
--- a/src/JwstBrick.vue
+++ b/src/JwstBrick.vue
@@ -188,7 +188,7 @@
             ><img alt="SciAct Logo" src="https://projects.cosmicds.cfa.harvard.edu/cds-website/logos/logo_sciact.png"
           /></a>
           <a href="https://nasa.gov/" target="_blank" rel="noopener noreferrer" class="pl-1"
-            ><img alt="SciAct Logo" src="https://projects.cosmicds.cfa.harvard.edu/cds-website/logos/NASA_Partner_color_300_no_outline.png"
+            ><img alt="NASA Grantee Logo" src="https://projects.cosmicds.cfa.harvard.edu/cds-website/logos/NASA_Grantee_color_no_outline.png"
           /></a>
         </div>
       </div>


### PR DESCRIPTION
As the title says, this updates the story to use the NASA Grantee logo rather than the NASA Partner one. This also fixes some preexisting bad alt text for the NASA logo.