### PR TITLE
Inject API key in deployment workflow

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -29,6 +29,8 @@ jobs:
 
       - name: Build
         run: yarn build
+        env:
+          VUE_APP_CDS_API_KEY: ${{ secrets.CDS_API_KEY }}
 
           # - name: BrowserStack env setup
           #   uses: browserstack/github-actions/setup-env@master


### PR DESCRIPTION
Currently the built app can't make requests to the server because the API key isn't included in the build. This PR fixes that.